### PR TITLE
Minor coreference fixes: remove prints, add input checks

### DIFF
--- a/evaluation_scripts/eval_coreference/evaluate.py
+++ b/evaluation_scripts/eval_coreference/evaluate.py
@@ -4,10 +4,35 @@ from evaluate_corefud import call_scorer
 
 
 def evaluate(data_ground_truth_path, data_submission_path):
+	gt_path = os.path.join(".", data_ground_truth_path, "ground_truth.conllu")
+	submission_path = os.path.join(".", data_submission_path, "submission.conllu")
+
+	with open(gt_path, "r") as f_gt:
+		gt_lines = list(
+			filter(lambda _ln_str: _ln_str.startswith("# newdoc"),
+				   map(lambda _s: _s.strip(), f_gt.readlines()))
+		)
+
+	with open(submission_path, "r") as f_gt:
+		submission_lines = list(
+			filter(lambda _ln_str: _ln_str.startswith("# newdoc"),
+				   map(lambda _s: _s.strip(), f_gt.readlines()))
+		)
+
+	if len(gt_lines) != len(submission_lines):
+		raise Exception(f"Number of documents in submission file ({len(submission_lines)}) is not equal to "
+						f"number of ground truth documents ({len(gt_lines)}) ")
+
+	# Extract doc ID from # newdoc line (e.g., "123.tsv" from "newdoc id = 123.tsv")
+	gt_ids = set(map(lambda _newdoc_ln: _newdoc_ln.split("=")[-1].strip(), gt_lines))
+	submission_ids = set(map(lambda _newdoc_ln: _newdoc_ln.split("=")[-1].strip(), submission_lines))
+	if len(submission_ids & gt_ids) != len(gt_ids):
+		raise Exception(f"Mismatch in document IDs. The following documents are missing in submission: "
+						f"{gt_ids - submission_ids}")
+
 	try:
 		# The script is just glue code around ufal/corefud-scorer
-		metrics = call_scorer(os.path.join(".", data_ground_truth_path, "ground_truth.conllu"),
-							  os.path.join(".", data_submission_path, "submission.conllu"))
+		metrics = call_scorer(gt_path, submission_path)
 		return metrics
 	except Exception as e:
 		raise Exception(f'Exception in metric calculation: {e}')

--- a/evaluation_scripts/eval_coreference/ua-scorer.py
+++ b/evaluation_scripts/eval_coreference/ua-scorer.py
@@ -258,7 +258,7 @@ def process_arguments(args):
 
     msg += " using {:s} match evaluation setting.\n".format(args['match'])
     msg += "The following metrics will be evaluated: {:s}\n".format(", ".join([name for name in args['metrics']]))
-    print(msg)
+    # print(msg)
     
     args['metrics'] = [(name, metric_dict[name]) for name in args['metrics']]
 
@@ -282,30 +282,30 @@ def evaluate(args):
         if name == 'non-referring':
             recall, precision, f1 = evaluate_non_referrings(
                 reader.doc_non_referring_infos)
-            print('============================================')
-            print('Non-referring markable identification scores:')
-            print('Recall: %.2f' % (recall * 100),
-                  ' Precision: %.2f' % (precision * 100),
-                  ' F1: %.2f' % (f1 * 100))
+            # print('============================================')
+            # print('Non-referring markable identification scores:')
+            # print('Recall: %.2f' % (recall * 100),
+            #       ' Precision: %.2f' % (precision * 100),
+            #       ' F1: %.2f' % (f1 * 100))
         elif name == 'bridging':
             score_ar, score_fbm, score_fbe = evaluator.evaluate_bridgings(reader.doc_bridging_infos)
             recall_ar, precision_ar, f1_ar = score_ar
             recall_fbm, precision_fbm, f1_fbm = score_fbm
             recall_fbe, precision_fbe, f1_fbe = score_fbe
 
-            print('============================================')
-            print('Bridging anaphora recognition scores:')
-            print('Recall: %.2f' % (recall_ar * 100),
-                  ' Precision: %.2f' % (precision_ar * 100),
-                  ' F1: %.2f' % (f1_ar * 100))
-            print('Full bridging scores (Markable Level):')
-            print('Recall: %.2f' % (recall_fbm * 100),
-                  ' Precision: %.2f' % (precision_fbm * 100),
-                  ' F1: %.2f' % (f1_fbm * 100))
-            print('Full bridging scores (Entity Level):')
-            print('Recall: %.2f' % (recall_fbe * 100),
-                  ' Precision: %.2f' % (precision_fbe * 100),
-                  ' F1: %.2f' % (f1_fbe * 100))
+            # print('============================================')
+            # print('Bridging anaphora recognition scores:')
+            # print('Recall: %.2f' % (recall_ar * 100),
+            #       ' Precision: %.2f' % (precision_ar * 100),
+            #       ' F1: %.2f' % (f1_ar * 100))
+            # print('Full bridging scores (Markable Level):')
+            # print('Recall: %.2f' % (recall_fbm * 100),
+            #       ' Precision: %.2f' % (precision_fbm * 100),
+            #       ' F1: %.2f' % (f1_fbm * 100))
+            # print('Full bridging scores (Entity Level):')
+            # print('Recall: %.2f' % (recall_fbe * 100),
+            #       ' Precision: %.2f' % (precision_fbe * 100),
+            #       ' F1: %.2f' % (f1_fbe * 100))
         else:
             recall, precision, f1 = evaluator.evaluate_documents(
                 reader.doc_discourse_deixis_infos if args['evaluate_discourse_deixis'] else reader.doc_coref_infos,
@@ -316,14 +316,14 @@ def evaluate(args):
                 conll += f1
                 conll_subparts_num += 1
 
-            print(name)
-            print('Recall: %.2f' % (recall * 100),
-                  ' Precision: %.2f' % (precision * 100),
-                  ' F1: %.2f' % (f1 * 100))
+            # print(name)
+            # print('Recall: %.2f' % (recall * 100),
+            #       ' Precision: %.2f' % (precision * 100),
+            #       ' F1: %.2f' % (f1 * 100))
 
     if conll_subparts_num == 3:
         conll = (conll / 3) * 100
-        print('CoNLL score: %.2f' % conll)
+        # print('CoNLL score: %.2f' % conll)
 
 def main():
     args = parse_arguments()


### PR DESCRIPTION
This PR removes unnecessary prints that break the online evaluation procedure, and adds basic input checks (as suggested by @szitnik):
- checking that number of documents in submission and ground truth files matches;
- checking that document IDs match